### PR TITLE
[박지훈] fix : keywordAdd,keywordRemove 메소드 -> keywordUpdate 메소드로 통합

### DIFF
--- a/src/main/java/com/team03/monew/interest/domain/Interest.java
+++ b/src/main/java/com/team03/monew/interest/domain/Interest.java
@@ -47,9 +47,9 @@ public class Interest {
         this.subscribeCount = 0;
     }
 
-    public void keywordAdd(String keyword) {this.keywords.add(keyword);}
-
-    public void keywordRemove(String keyword) { this.keywords.remove(keyword); }
+    public void keywordUpdate(List<String> keyword) {
+        this.keywords = keyword;
+    }
 
     public void subscribeAdd() {this.subscribeCount = this.subscribeCount + 1; }
 


### PR DESCRIPTION
## Summary (요약)
<!-- 이 PR의 목적과 주요 변경 사항을 간단히 설명하세요. -->
- [x] keywordAdd,keywordRemove 메소드 -> keywordUpdate 메소드로 통합
     - keyword 업데이트시 수정된 키워드만 받는게 아니라 변경된 기워드 배열을 받기 떄문에 수정함

## Details (작업 내용)
<!-- 이 PR의 작업 내용을 기재해주세요. -->
- keywordAdd, keywordRemove 메서드는 키워드 단일로 입력 삭제하는 메서드인 정작 수정 때 받는 키워드는 이미 변경된 키워드 배열을 받는 것 때문에 keywordUpdate 메서드로 합치고 리스트 형태를 변경하는 방식으로 수정했습니다

## Related Issues (연관 이슈)
- close #78 