### PR TITLE
[이치호] feat : 댓글 관리, 목록 조회

### DIFF
--- a/src/main/java/com/team03/monew/comment/controller/CommentController.java
+++ b/src/main/java/com/team03/monew/comment/controller/CommentController.java
@@ -1,11 +1,8 @@
 package com.team03.monew.comment.controller;
 
-import com.team03.monew.comment.dto.CommentDto;
-import com.team03.monew.comment.dto.CommentRegisterRequest;
-import com.team03.monew.comment.dto.CommentUpdateRequest;
-import com.team03.monew.comment.dto.CommentUserIdRequest;
-import com.team03.monew.comment.dto.CursorPageRequestCommentDto;
+import com.team03.monew.comment.dto.*;
 import com.team03.monew.comment.service.CommentService;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
@@ -18,11 +15,16 @@ public class CommentController {
 
     private final CommentService commentService;
 
+    public CommentController(CommentService commentService) {
+        this.commentService = commentService;
+    }
+
     @GetMapping
-    public ResponseEntity<CommentDto> listRead(
+    public ResponseEntity<CursorPageResponseCommentDto> listRead(
             @RequestParam CursorPageRequestCommentDto request
     ) {
-        return null;
+        CursorPageResponseCommentDto response = commentService.getCommentList(request);
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping

--- a/src/main/java/com/team03/monew/comment/repository/CommentRepository.java
+++ b/src/main/java/com/team03/monew/comment/repository/CommentRepository.java
@@ -1,4 +1,13 @@
 package com.team03.monew.comment.repository;
 
-public class CommentRepository {
+import com.team03.monew.comment.domain.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, UUID>, CommentRepositoryCustom {
+
+    Long countByArticleIdAndDeletedAtIsNull(UUID articleId);
 }

--- a/src/main/java/com/team03/monew/comment/repository/CommentRepositoryCustom.java
+++ b/src/main/java/com/team03/monew/comment/repository/CommentRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.team03.monew.comment.repository;
+
+import com.team03.monew.comment.dto.CommentDto;
+import com.team03.monew.comment.dto.CursorPageRequestCommentDto;
+
+import java.util.List;
+
+public interface CommentRepositoryCustom {
+    List<CommentDto> findByCursor(CursorPageRequestCommentDto request);
+}

--- a/src/main/java/com/team03/monew/comment/repository/CommentRepositoryCustomImpl.java
+++ b/src/main/java/com/team03/monew/comment/repository/CommentRepositoryCustomImpl.java
@@ -1,0 +1,92 @@
+package com.team03.monew.comment.repository;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.team03.monew.comment.domain.QComment;
+import com.team03.monew.comment.dto.CommentDto;
+import com.team03.monew.comment.dto.CursorPageRequestCommentDto;
+import com.team03.monew.commentLike.domain.QCommentLike;
+import com.team03.monew.user.domain.QUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentRepositoryCustomImpl implements CommentRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+    private final QComment comment = QComment.comment;
+    private final QUser user = QUser.user;
+    private final QCommentLike commentLike = QCommentLike.commentLike;
+
+    @Override
+    public List<CommentDto> findByCursor(CursorPageRequestCommentDto request) {
+        return queryFactory
+                .select(Projections.constructor(CommentDto.class,
+                        comment.id,
+                        comment.articleId,
+                        comment.userId,
+                        user.nickname,
+                        comment.content,
+                        comment.likeCount,
+                        commentLike.userId.eq(request.userId()),
+                        comment.creationAt
+                ))
+                .from(comment)
+                .leftJoin(user).on(comment.userId.eq(user.userId))
+                .where(
+                        articleIdEq(request.articleId()),
+                        cursorCondition(request),
+                        afterCondition(request.after())
+                )
+                .orderBy(getOrderSpecifier(request))
+                .limit(request.limit() != null ? request.limit() : 20)
+                .fetch();
+    }
+
+    private BooleanExpression articleIdEq(UUID articleId) {
+        return articleId != null ? comment.articleId.eq(articleId) : null;
+    }
+
+    private BooleanExpression cursorCondition(CursorPageRequestCommentDto request) {
+        if (request.cursor() == null) {
+            return null;
+        }
+
+        String orderBy = request.orderBy() != null ? request.orderBy() : "creationAt";
+        boolean isAsc = "asc".equalsIgnoreCase(request.direction());
+
+        if ("likeCount".equals(orderBy)) {
+            Long cursorLikeCount = Long.parseLong(request.cursor());
+            return isAsc ? comment.likeCount.gt(cursorLikeCount)
+                    : comment.likeCount.lt(cursorLikeCount);
+        } else {
+            LocalDateTime cursorDateTime = LocalDateTime.parse(request.cursor());
+            return isAsc ? comment.creationAt.gt(cursorDateTime)
+                    : comment.creationAt.lt(cursorDateTime);
+        }
+    }
+
+    private BooleanExpression afterCondition(LocalDateTime after) {
+        return after != null ? comment.creationAt.after(after) : null;
+    }
+
+    private OrderSpecifier<?> getOrderSpecifier(CursorPageRequestCommentDto request) {
+        String orderBy = request.orderBy() != null ? request.orderBy() : "creationAt";
+        boolean isAsc = "asc".equalsIgnoreCase(request.direction());
+
+        // 좋아요 정렬
+        if ("likeCount".equals(orderBy)) {
+            return isAsc ? comment.likeCount.asc() : comment.likeCount.desc();
+        }
+
+        // 날짜 정렬 (기본값)
+        return isAsc ? comment.creationAt.asc() : comment.creationAt.desc();
+    }
+}

--- a/src/main/java/com/team03/monew/comment/service/BasicCommentService.java
+++ b/src/main/java/com/team03/monew/comment/service/BasicCommentService.java
@@ -1,0 +1,75 @@
+package com.team03.monew.comment.service;
+
+import com.team03.monew.comment.domain.Comment;
+import com.team03.monew.comment.dto.*;
+import com.team03.monew.comment.repository.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BasicCommentService implements CommentService{
+
+    private final CommentRepository commentRepository;
+
+    @Override
+    public CursorPageResponseCommentDto getCommentList(CursorPageRequestCommentDto request) {
+        int limit = request.limit() != null ? request.limit() : 20;
+
+        CursorPageRequestCommentDto modifiedRequest = new CursorPageRequestCommentDto(
+                request.articleId(),
+                request.orderBy(),
+                request.direction(),
+                request.cursor(),
+                request.after(),
+                limit + 1,
+                request.userId()
+        );
+
+        List<CommentDto> comments = commentRepository.findByCursor(modifiedRequest);
+
+        boolean hasNext = comments.size() > limit;
+        if (hasNext) {
+            comments = comments.subList(0, limit);
+        }
+
+        String nextCursor = null;
+        LocalDateTime nextAfter = null;
+        if (hasNext && !comments.isEmpty()) {
+            CommentDto lastComment = comments.get(comments.size() - 1);
+
+            if ("likeCount".equals(request.orderBy())) {
+                nextCursor = String.valueOf(lastComment.likeCount());
+            } else {
+                nextCursor = lastComment.createdAt().toString();
+            }
+            nextAfter = lastComment.createdAt();
+        }
+
+        Slice<CommentDto> slice = new SliceImpl<>(
+                comments,
+                PageRequest.of(0, limit),
+                hasNext
+        );
+
+        Long totalElements = commentRepository.countByArticleIdAndDeletedAtIsNull(request.articleId());
+
+        return new CursorPageResponseCommentDto(
+                slice,
+                nextCursor,
+                nextAfter,
+                comments.size(),
+                totalElements,
+                hasNext
+        );
+    }
+}

--- a/src/main/java/com/team03/monew/comment/service/CommentService.java
+++ b/src/main/java/com/team03/monew/comment/service/CommentService.java
@@ -1,4 +1,9 @@
 package com.team03.monew.comment.service;
 
-public class CommentService {
+import com.team03.monew.comment.dto.*;
+
+import java.util.UUID;
+
+public interface CommentService {
+    CursorPageResponseCommentDto getCommentList(CursorPageRequestCommentDto request);
 }


### PR DESCRIPTION
## Summary (요약)
<!-- 이 PR의 목적과 주요 변경 사항을 간단히 설명하세요. -->
- [x] 서비스 : 요청에 맞는 댓글 리스트를 반환합니다.
- [x] 레포지토리 : 커서 페이지네이션 조회를 위한 QueryDSL 구성
## Details (작업 내용)
댓글 관리 중 커서 페이지네이션 목록 조회를 구현하였습니다.
시간관계상 테스트는 건너뛰었으며 금일 저녁 리팩토링 과정에서 추가 PR 하겠습니다.

## Related Issues (연관 이슈)
- Issue: #28 