### PR TITLE
[이치호] feat : 댓글 관리, 논리/물리 삭제

### DIFF
--- a/src/main/java/com/team03/monew/comment/controller/CommentController.java
+++ b/src/main/java/com/team03/monew/comment/controller/CommentController.java
@@ -51,9 +51,12 @@ public class CommentController {
     }
 
     @DeleteMapping("{commentId}")
-    public void delete(
+    public ResponseEntity<Void> delete(
             @PathVariable UUID commentId
-    ) {}
+    ) {
+        commentService.deleteComment(commentId);
+        return ResponseEntity.noContent().build();
+    }
 
     @PatchMapping("{commentId}")
     public void update(
@@ -63,7 +66,10 @@ public class CommentController {
     ) {}
 
     @DeleteMapping("{commentId}/hard")
-    public void deleteHard(
+    public ResponseEntity<Void> deleteHard(
             @PathVariable UUID commentId
-    ) {}
+    ) {
+        commentService.deleteCommentHard(commentId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/team03/monew/comment/domain/Comment.java
+++ b/src/main/java/com/team03/monew/comment/domain/Comment.java
@@ -39,6 +39,10 @@ public class Comment {
     @Column(name = "updateAt", nullable = false)
     private LocalDateTime updateAt;
 
+    // 논리 삭제용 필드 추가
+    @Column(name = "deletedAt", nullable = true)
+    private LocalDateTime deletedAt;
+
     private Comment(
             UUID articleId,
             UUID userId,
@@ -75,4 +79,11 @@ public class Comment {
         this.likeCount--;
     }
 
+    public void softDelete() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public boolean isDeleted() {
+        return deletedAt != null;
+    }
 }

--- a/src/main/java/com/team03/monew/comment/service/BasicCommentService.java
+++ b/src/main/java/com/team03/monew/comment/service/BasicCommentService.java
@@ -72,4 +72,21 @@ public class BasicCommentService implements CommentService{
                 hasNext
         );
     }
+
+    // 논리 삭제
+    @Transactional
+    public void deleteComment(UUID commentId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("댓글 찾을 수 없음"));
+
+        comment.softDelete();
+    }
+
+    @Transactional
+    public void deleteCommentHard(UUID commentId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("댓글 찾을 수 없음"));
+
+        commentRepository.deleteById(commentId);
+    }
 }

--- a/src/main/java/com/team03/monew/comment/service/CommentService.java
+++ b/src/main/java/com/team03/monew/comment/service/CommentService.java
@@ -6,4 +6,6 @@ import java.util.UUID;
 
 public interface CommentService {
     CursorPageResponseCommentDto getCommentList(CursorPageRequestCommentDto request);
+    void deleteComment(UUID commentId);
+    void deleteCommentHard(UUID commentId);
 }


### PR DESCRIPTION
## Summary (요약)
<!-- 이 PR의 목적과 주요 변경 사항을 간단히 설명하세요. -->
- [x] 도메인 : 삭제일과 삭제 확인 로직 추가
- [x] 컨트롤러 : 반환형 수정

## Details (작업 내용)
댓글 관리 기능요구사항 중 논리 삭제는 삭제일을 지니고 있을 시 사용 불가능한 객체로 취급이고,  
물리 삭제는 해당 객체의 댓글 데이터 열 삭제를 뜻하는 요구사항으로 구현하였습니다.

## Related Issues (연관 이슈)
- Issue: #27 